### PR TITLE
Add note re camera cable for RPi Zero

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Pi-KVM supports several different hardware configurations, referred to as **plat
     - 2x USB-A to USB-micro cable (male-male).
 * Only for Raspberry Pi ZeroW:
   * 2x USB A-to-micro cables (male-male, for power and keyboard & mouse emulator).
+  * 1x Raspberry Pi Zero Camera Cable (if using HDMI to CSI-2 Bridge)
 * For ATX control (optional):
   - [4x MOSFET relays OMRON G3VM-61A1](https://www.digikey.com/products/en?keywords=G3VM-61A1).
   - 4x 390 Ohm resistors.


### PR DESCRIPTION
RPi Zero uses smaller connector for camera, so, cable that is
shipped with recommended HDMI to CSI-2 Bridge will not work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pikvm/pikvm/52)
<!-- Reviewable:end -->
