### PR TITLE
Add `rw` command 

### DIFF
--- a/pages/flashing_os.md
+++ b/pages/flashing_os.md
@@ -45,7 +45,8 @@ Decompress and flash image and follow to the [final steps](#the-final-steps). Be
 
 3. Congratulations! Your Pi-KVM will be available via SSH (`ssh root@<addr>` with password `root` by default) and HTTPS (try to open in a browser the URL `https://<addr>`, the login `admin` and password `admin` by default). For HTTPS a self-signed certificate is used by default.
 
-4. To change the root password use command `passwd` via SSH or webterm. To change Pi-KVM web password use `kvmd-htpasswd set admin`.
+4. To change the root password use command `passwd` via SSH or webterm. To change Pi-KVM web password use `kvmd-htpasswd set admin`. 
+   As indicated on the login screen use `rw` to make the root filesystem writable, before issuing these commands.
 
 5. After installation, we recommend you to update your operating system:
     ```shell


### PR DESCRIPTION
Users should be reminded to issue `rw` in case the first thing they want to do is change password.
It is mentioned in the login screen, and explicit for step 5 , but not mentioned here. 
The error message gives if the root filesystem is read-only is  "passwd: Authentication token lock busy" is particularly obscure.