### PR TITLE
Elevate to root before enabling systemd units

### DIFF
--- a/pages/v3.md
+++ b/pages/v3.md
@@ -47,10 +47,12 @@ To use Pi-KVM v3, you will need the following things, which are NOT included in 
 4. Power it up
 5. If your kit includes the display and/or the fan, you'll need to turn them on after installation:
    ```bash
+   su - # The default password is "root"
    rw
    systemctl enable --now kvmd-oled # For the display
    systemctl enable --now kvmd-fan  # For the fan
    ro
+   logout
    ```
 5. **Important!** If you are going to use GPIO pins to control a relay, KVM switch, or anything else, be sure to check the v3 shield pinout. Many ports are busy with internal functions. Before using them for your own use, you must disable them, otherwise you may damage the device.
    


### PR DESCRIPTION
Ensure that the instructions work no matter what user is executing them by explicitly su-ing to root.

The kvmd-webterm user does not have permission to execute these commands.