### PR TITLE
Remove mention of on-board UART from xh-hk4401

### DIFF
--- a/docs/xh_hk4401.md
+++ b/docs/xh_hk4401.md
@@ -38,12 +38,9 @@ For this you will need:
 * 2x 2n7000 MOSFETs
 * 2x 10K resistors
 * 1x USB Micro connector, or sacrificial micro USB cable
-* *Optional:* USB UART adapter
+* USB UART adapter
 
 <img src="xh-hk4401_circuit.jpg" />
-
-You can connect this either via a USB UART adapter, or directly to the Raspberry Pi: `GND -> Pin 6`, `TX -> Pin 8`, `RX -> Pin 10`.
-On the v3 PiKVM hat you will need to disable the UART jumpers to use the on-board UART.
 
 !!! note
     Please search online for USB pinouts to ensure you connect it properly.


### PR DESCRIPTION
In light of the conversation on discord and the GPIO on the Pi not being
5v tolerant, it is best to just not mention it as an option.