### PR TITLE
Add notes about serial port voltages, device, etc

### DIFF
--- a/docs/v3.md
+++ b/docs/v3.md
@@ -147,8 +147,8 @@ To manage the power of your computer, you will need to install an ATX adapter bo
     3. **SPI and GPIO** for the custom extension boards.
     4. **Audio capture** jumpers.
     5. **UART access** pins.
-    6. **Serial console port** (for the Raspberry Pi or server console access).
-    7. **USB-C console port**.
+    6. **Serial console port** (default: /dev/ttyAMA0, RS-422 +6V/-6V, for the Raspberry Pi or server console access).
+    7. **USB-C console port** (shared with #6 above).
     8. **Power** and **activity LEDs**.
     9. **USB-C power input**.
     10. **I2C display connector**.

--- a/docs/v3.md
+++ b/docs/v3.md
@@ -147,7 +147,7 @@ To manage the power of your computer, you will need to install an ATX adapter bo
     3. **SPI and GPIO** for the custom extension boards.
     4. **Audio capture** jumpers.
     5. **UART access** pins.
-    6. **Serial console port** (default: /dev/ttyAMA0, RS232 input, outputs +6V/-6V (RS-422), for the Raspberry Pi or server console access).
+    6. **Serial console port** (default: /dev/ttyAMA0, RS232 input, outputs +6V/-6V, for the Raspberry Pi or server console access).
     7. **USB-C console port** (shared with #6 above).
     8. **Power** and **activity LEDs**.
     9. **USB-C power input**.

--- a/docs/v3.md
+++ b/docs/v3.md
@@ -147,7 +147,7 @@ To manage the power of your computer, you will need to install an ATX adapter bo
     3. **SPI and GPIO** for the custom extension boards.
     4. **Audio capture** jumpers.
     5. **UART access** pins.
-    6. **Serial console port** (default: /dev/ttyAMA0, outputs RS-422 +6V/-6V, for the Raspberry Pi or server console access).
+    6. **Serial console port** (default: /dev/ttyAMA0, RS232 input, outputs +6V/-6V (RS-422), for the Raspberry Pi or server console access).
     7. **USB-C console port** (shared with #6 above).
     8. **Power** and **activity LEDs**.
     9. **USB-C power input**.

--- a/docs/v3.md
+++ b/docs/v3.md
@@ -147,7 +147,7 @@ To manage the power of your computer, you will need to install an ATX adapter bo
     3. **SPI and GPIO** for the custom extension boards.
     4. **Audio capture** jumpers.
     5. **UART access** pins.
-    6. **Serial console port** (default: /dev/ttyAMA0, RS-422 +6V/-6V, for the Raspberry Pi or server console access).
+    6. **Serial console port** (default: /dev/ttyAMA0, outputs RS-422 +6V/-6V, for the Raspberry Pi or server console access).
     7. **USB-C console port** (shared with #6 above).
     8. **Power** and **activity LEDs**.
     9. **USB-C power input**.

--- a/docs/v3.md
+++ b/docs/v3.md
@@ -148,7 +148,7 @@ To manage the power of your computer, you will need to install an ATX adapter bo
     4. **Audio capture** jumpers.
     5. **UART access** pins.
     6. **Serial console port** (default: /dev/ttyAMA0, RS232 input, outputs +6V/-6V, for the Raspberry Pi or server console access).
-    7. **USB-C console port** (shared with #6 above).
+    7. **USB-C console port** (shared with #6 above, takes priority over RJ45).
     8. **Power** and **activity LEDs**.
     9. **USB-C power input**.
     10. **I2C display connector**.


### PR DESCRIPTION
* Default device on pi-kvm image
* Supported voltages
* Note that the usb-c port is shared with the RJ45 serial port