### PR TITLE
Add information about outgoing serial console

### DIFF
--- a/docs/community_faq.md
+++ b/docs/community_faq.md
@@ -179,6 +179,17 @@ lrwxrwxrwx 1 root root 6 Mar 15 09:07 /dev/kvmd-video -> video0
 - If you are getting an Indian looking screen, please clear the browser cache or use private/incog window
 
 
+### How can I use the serial console to access to access other devices 
+- You need to stop the service which listens on the ttyAMA0:
+-- rw
+-- systemctl stop serial-getty@ttyAMA0.service
+- If you want this change permanent (not starting again after reboot), you can disable this service:
+-- systemctl disable serial-getty@ttyAMA0.service
+- Important:
+-- Only USB OR the RJ-45 serial connector are working!
+-- I read about removing "ttyAMA0" from /boot/cmdline.txt, but at my file, this was not mentioned
+
+
 ### Misc stuff
 - Fully working [example](https://docs.google.com/document/d/1wgBZHxwpbJWkJBD3I8ZkZxSDxt0DdNDDYRNtVoL_vK4) of a Pi4 USB-HDMI KVM attached to AIMOS 4-port HDMI KVM switch (8 port is on AliExpress), with keyboard hotkey switching between inputs, and mass storage media emulation on a Pi Zero W
 - PiKVM that mitigates HDMI backpower and requires no splitter board [here](https://docs.google.com/document/d/1M9xUgNE_-P8GydKr_3qIgXUR9YzqApHNPhetRv3pcsE/edit)


### PR DESCRIPTION
Hey, after I searched a lot in the docs and then in the discord with multiple people asking about this and getting the information about searching, because it got asked before, I think adding this would be helpful. Also because it is mentioned that the PiKVM can do this: "CISCO-style and USB serial console port (to manage PiKVM OS **or to connect the server**)".
So, I hope this is would be a good information added to the FAQ or any other part of the docs.
Thanks for the support on the discord, where I found this information.