### PR TITLE
Add information about outgoing serial console

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -147,6 +147,25 @@ As a first step, we recommend carefully reading our documentation on [GitHub](ht
 
     Now re-edit your `/etc/kvmd/override.yaml` file and just use tab to get the right spacing, you might need to delete the current leading "spaces" to ensure proper formatting.
 
+??? question "How can I use the serial console to access to access other devices"
+    you need to stop the service which listens on the ttyAMA0:
+    
+    ```
+    rw
+    systemctl stop serial-getty@ttyAMA0.service
+    ```
+    
+    If you want this change permanent (not starting again after reboot), you can disable this service, ('enable' to reverse this decision):
+    
+    ```
+    systemctl disable serial-getty@ttyAMA0.service
+    ```
+    
+   Important:
+   * Only USB OR the RJ-45 serial connector will work, you can't use them together! 
+   * If you disable the service permanently, you can't recover your device via serial console if you need this.
+   * There are some reports, that you need to remove "ttyAMA0" from /boot/cmdline.txt, but this is not needed on new installations.
+
 
 ## First steps
 


### PR DESCRIPTION
Hey, after I searched a lot in the docs and then in the discord with multiple people asking about this and getting the information about searching, because it got asked before, I think adding this would be helpful. Also because it is mentioned that the PiKVM can do this: "CISCO-style and USB serial console port (to manage PiKVM OS or to connect the server)".
So, I hope this is would be a good information added to the FAQ or any other part of the docs.
Thanks for the support on the discord, where I found this information.

(In #670 it was mentioned I should put this here instead of the community FAQ.)