### PR TITLE
Add explanation for Y cable

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,10 @@ PiKVM supports several different hardware configurations, referred to as **platf
   - **Recommended**: [HDMI to CSI-2 bridge based on TC358743](https://aliexpress.com/item/4000102166176.html) - low latency, more reliable, **H.264 video**.
   - ... or [HDMI to USB dongle](https://aliexpress.com/item/4001043540669.html) (not available for ZeroW and Zero2W) - high latency >200ms, [not very reliable](#a-few-words-about-hdmi-usb-dongle-h264-is-not-officially-supported-at-this-time)), H.264 is not supported.
 * Only for Raspberry Pi 4: parts for Y-splitter cable (**one variant at your choice**):
+  *  <details><summary>❓ Why is this cable necessary?</summary>
+     On a Raspberry Pi only the USB port that receives power is capable of acting as a USB Device. The other USB ports are capable only of acting as USB Hosts. Therefore a special cable must be used on the USB power port that it can simultanously act as USB Device for the PC/server and receive external DC power.
+      </details>
+
   * <details><summary>:exclamation:Variant #1:exclamation:: (No mod solution - Amazon) Y cable with power blocker ends.</summary>
     <ul>
       <li>1x USB-A to USB-A cable (male-male).</li>


### PR DESCRIPTION
I didn't understand why the Y splitter cable was needed until I happened upon an explanation in an external guide. This PR therefore adds a one line explanation for why it is needed. 