### PR TITLE
Update letsencrypt.md - Enable auto cert renewal for route53

### DIFF
--- a/docs/letsencrypt.md
+++ b/docs/letsencrypt.md
@@ -152,8 +152,8 @@ This example shows that PiKVM may not be accessible from the internet, but you c
     
 4. Obtain the certificate:
    ```
-   # export AWS_SHARED_CREDENTIALS_FILE="/var/lib/kvmd/pst/data/certbot/runroot/.route53.auth"
-   # kvmd-certbot certonly \
+   export AWS_SHARED_CREDENTIALS_FILE="/var/lib/kvmd/pst/data/certbot/runroot/.route53.auth"
+   kvmd-certbot certonly \
        --dns-route53 \
        --agree-tos \
        -n \
@@ -161,4 +161,14 @@ This example shows that PiKVM may not be accessible from the internet, but you c
        -d pikvm.example.com
    ```
 
-4. Next follow the basic guide.
+4. Enable automatic certificate renewal:
+
+   Create the file: */etc/conf.d/kvmd-certbot* with the following contents so the renewall service can find the authentication file containing the AWS credentials:
+   ```
+   AWS_SHARED_CREDENTIALS_FILE="/var/lib/kvmd/pst/data/certbot/runroot/.route53.auth"
+   ```
+   
+   Now enable the renewal service:
+   ```
+   systemctl enable --now kvmd-certbot.timer
+   ```


### PR DESCRIPTION
Added AWS Route53-specific instructions for enabling automatic certificate renewal.