### PR TITLE
FAQ add setting timezone,date & time, and date check before pacman

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -260,11 +260,20 @@ As a first step, we recommend carefully reading our documentation on [GitHub](ht
         * Do the same in `/etc/fstab` for the `/boot` partition.
         * Comment `tmpfs` lines in `/etc/fstab` for `/var/lib` and `/var/log`.
         !!! danger "But again: DON'T DO THIS"
-
+        
+??? question "How to set the date, time and timezone from command line?"
+    * Become root with: `su -` or `sudo -s`
+    * Enable read/write with: `rw`
+    * Find your timezone with: `timedatectl list-timezones`
+    * Set the timezone with: `timedatectl set-timezone <YourTimeZoneHere>` e.g. `timedatectl set-timezone Australia/Victoria`
+    * Set the time and date with: `timedatectl set-time 'YYYY-MM-DD HH:MM:SS'` e.g. `timedatectl set-time '2023-02-26 14:50:10'`
+    * If you have hardware clock, update it with: `hwclock --systohc` , then check it with `hwclock --show`
+    
 
 ??? question "How do I install or remove packages in PiKVM OS?"
     PiKVM OS is based on Arch Linux ARM and uses the [pacman](https://wiki.archlinux.org/title/Pacman) package manager.
 
+    * Ensure the date is correct: `date`. Otherwise you may get the error `SSL certificate problem: certificate is not yet valid`
     * Switch filesystem to RW-mode: `rw`.
     * Find some packages (`emacs` for example): `pacman -Ss emacs`.
     * Install it, while keeping the system updated: `pacman -Syu emacs`.
@@ -276,9 +285,13 @@ As a first step, we recommend carefully reading our documentation on [GitHub](ht
 ??? question "How do I update PiKVM with the latest software?"
     This is ONLY recommended if you need a feature, otherwise this should ONLY be done if you are physically at the device and can reflash the sd card as a means of recovery. PiKVM OS is based on Arch Linux ARM and is fully updated from the repository by a regular package manager. Connect to your PiKVM via ssh and run:
 
-    ```
+   * Ensure the date is correct: `date`. Otherwise you may get the error `SSL certificate problem: certificate is not yet valid`
+   * Run the following
+   ```
+    # date
     # rw
     # pacman -Syu
+    # sync
     # reboot
     ```
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -262,12 +262,15 @@ As a first step, we recommend carefully reading our documentation on [GitHub](ht
         !!! danger "But again: DON'T DO THIS"
         
 ??? question "How to set the date, time and timezone from command line?"
-    * Become root with: `su -` or `sudo -s`
-    * Enable read/write with: `rw`
-    * Find your timezone with: `timedatectl list-timezones`
-    * Set the timezone with: `timedatectl set-timezone <YourTimeZoneHere>` e.g. `timedatectl set-timezone Australia/Victoria`
-    * Set the time and date with: `timedatectl set-time 'YYYY-MM-DD HH:MM:SS'` e.g. `timedatectl set-time '2023-02-26 14:50:10'`
-    * If you have hardware clock, update it with: `hwclock --systohc` , then check it with `hwclock --show`
+
+    * Become root with the command `su -` or `sudo -s`.
+    * Enable read/write with the command `rw`.
+    * Find your timezone string e.g. `timedatectl list-timezones` or `timedatectl list-timezones | grep -i australia`.
+    * Set the timezone with `timedatectl set-timezone <YourTimeZoneHere>` e.g. `timedatectl set-timezone Australia/Victoria`.
+    * Stop the time syncing service with `systemctl stop systemd-timesyncd` as this will prevent the next step if running.
+    * Set the time and date with `timedatectl set-time 'YYYY-MM-DD HH:MM:SS'` e.g. `timedatectl set-time '2023-02-26 14:50:10'`.
+    * If you have hardware clock e.g. V3 & V4 HAT, update it with `hwclock --systohc` , then check it with `hwclock --show`.
+    * Switch filesystem to RO-mode with the command `ro`.
     
 
 ??? question "How do I install or remove packages in PiKVM OS?"
@@ -292,7 +295,7 @@ As a first step, we recommend carefully reading our documentation on [GitHub](ht
     # rw
     # pacman -Syu
     # sync
-    # reboot
+    # reboot # Allow 10 to 15 minutes for a response.
     ```
 
     Pacman saves all installed packages in a compressed format so that you can roll back to the old version if something goes wrong. After you've updated and made sure everything works, (ONLY for older images, newer images has this partition expended and no longer has this issue) it makes sense to clear the package cache so that it doesn't take up space on the SD card: `rw; rm -rf /var/cache/pacman/pkg; ro`.


### PR DESCRIPTION
`pacman` needs the date on the system to be correct as SSL Certificates used on repo have a start and a end date. If the system date is in the past it can lead to the error below:
```
[root@pikvm ~]# pacman -Syu
:: Synchronizing package databases...
 core                                                                                              269.5 KiB   119 KiB/s 00:02 [#############################################################################] 100%
 extra                                                                                               2.6 MiB   875 KiB/s 00:03 [#############################################################################] 100%
 community                                                                                           6.4 MiB   858 KiB/s 00:08 [#############################################################################] 100%
 alarm                                                                                              96.6 KiB   268 KiB/s 00:00 [#############################################################################] 100%
 aur is up to date
 pikvm.db failed to download
error: failed retrieving file 'pikvm.db' from files.pikvm.org : SSL certificate problem: certificate is not yet valid
error: failed to synchronize all databases (download library error)
```

This change to the FAQ adds instruction on how to set the timezone, date & time, and extra steps when using pacman to check if the date is correct.  Time syncing services can take considerable time to sync the clock to the correct time, if out by a significate amount. The user community may not be aware of this when running pacman, and may try to patch their systems before the time is correct.