### PR TITLE
Fix formatting error in FAQ

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -336,7 +336,7 @@ As a first step, we recommend carefully reading our documentation on [GitHub](ht
             enabled: false
     ```
 
-    ... then restart `kvmd`:
+    Then restart `kvmd`:
 
     ```
     [root@pikvm ~]# systemctl restart kvmd


### PR DESCRIPTION
This line is currently escaped from the FAQ formatting. I can't test locally if this will fix it but I think the `...` at the beginning did it.

<img width="867" alt="image" src="https://github.com/pikvm/pikvm/assets/44177686/5222cd61-9ad3-44cd-817e-18c880d99871">
