### PR TITLE
Update audio.md to link to EDID docs

### DIFF
--- a/docs/audio.md
+++ b/docs/audio.md
@@ -31,7 +31,7 @@ This feature allows you to receive audio over an HDMI cable and transmit it to t
    }
    ```
 
-4. Enable the basic audio in the EDID:
+4. Enable the basic audio in the [EDID](https://docs.pikvm.org/edid/) in the file `/etc/kvmd/tc358743-edid.hex`:
    ```
    # kvmd-edidconf --set-audio=yes
    ```


### PR DESCRIPTION
The audio instructions left the user googling to learn more about the EDID if they were not aware of it already. 
Now a link has been made between the two pages.