### PR TITLE
wifi: add `key_mgmt=WPA-PSK-SHA256` and `ieee80211w=1` by default

### DIFF
--- a/docs/wifi.md
+++ b/docs/wifi.md
@@ -39,6 +39,7 @@ Alternatively you can connect to the PiKVM via SSH. The built-in Web Terminal (a
 
     ```
     # wpa_passphrase 'MyNetwork' 'P@assw0rd' > /etc/wpa_supplicant/wpa_supplicant-wlan0.conf
+    # sed -i '$i\\tkey_mgmt=WPA-PSK-SHA256 WPA-PSK\n\tieee80211w=1' /etc/wpa_supplicant/wpa_supplicant-wlan0.conf
     # chmod 640 /etc/wpa_supplicant/wpa_supplicant-wlan0.conf
     ```
     


### PR DESCRIPTION
Connect to WPA2/WPA3 mixed Access Point without setting `key_mgmt=WPA-PSK-SHA256` will fail. Add this note to users to avoid the same trouble.