### PR TITLE
Align WebRTC docs with config

### DIFF
--- a/docs/webrtc.md
+++ b/docs/webrtc.md
@@ -78,7 +78,7 @@ In rare cases, WebRTC may not work. Here some common tips:
 
 * Tricky IPv6 configuration on the network can be a problem. IPv6 support for WebRTC in PiKVM is still in its infancy, so if your network has IPv4, it will be easiest to disable IPv6 on PiKVM. To do this, switch the file system to write mode using `rw` command, add option `ipv6.disable_ipv6=1` to `/boot/cmdline.txt` and perform `reboot`. Also see [here](https://wiki.archlinux.org/title/IPv6#Disable_IPv6).
 
-* A paranoid firewall when you try to connect to the PiKVM by forwarding port 443 to the Internet from the internal network. WebRTC is not enough of this, it uses UDP on ports 10000-20000 for a P2P connection. Make sure that the Firewall does not block them.
+* A paranoid firewall when you try to connect to the PiKVM by forwarding port 443 to the Internet from the internal network. WebRTC is not enough of this, it uses UDP on ports 20000-40000 for a P2P connection. Make sure that the Firewall does not block them.
 
 * If nothing helps, open the browser's JS console and look at the log, and contact our community via [Discord](https://discord.gg/bpmXfz5). Developers and/or experienced users will definitely help you.
 


### PR DESCRIPTION
In [pikvm/kvmd, kvmd/configs/janus/janus.jcfg](https://github.com/pikvm/kvmd/blob/d3dc09710081e12d92e565c4ad040274c887b6d0/configs/janus/janus.jcfg#L12), the port range is specified as 20000-40000. Only allowing 10000-20000 doesn't work.