### PR TITLE
Update v2.md

### DIFF
--- a/docs/v2.md
+++ b/docs/v2.md
@@ -48,7 +48,7 @@
             * *x1* USB-A to USB-C cable (male-male).
             * *x1* [USB splitter](https://www.amazon.com/dp/B08C5FWQND).
             * *x1* [USB Power Blocker](https://www.amazon.com/gp/product/B092MLT2J3) - Will go into the USB-A end towards the target host.
-            * *x1* [Official USB-C Power Supply](https://www.raspberrypi.com/products/type-c-power-supply/).
+            * *x1* [Raspberry Pi Official USB-C Power Supply](https://www.raspberrypi.com/products/type-c-power-supply/).
 
         ??? note "... or Variant #3: Power supply + DIY Y-splitter for soldering"
 
@@ -60,7 +60,7 @@
 
         * *x1* USB-A to USB-Micro cable (male-male).
         * *x1* [Raspberry Pi Zero Camera Cable](https://www.amazon.com/Arducam-Raspberry-Camera-Ribbon-Extension/dp/B085RW9K13). *Not compatible with Auvidea B101*.
-        * *x1* [Official USB-Micro Power Supply](https://www.amazon.com/Capture-Streaming-Broadcasting-Conference-Teaching/dp/B09FLN63B3).
+        * *x1* [Raspberry Pi Official USB-Micro Power Supply](https://www.raspberrypi.com/products/micro-usb-power-supply/).
 
 5. **Optional features:**
 


### PR DESCRIPTION
For Pi 4 and Pi Zero 2 W instructions:

Added Raspberry Pi to the beginning of the official usb power supply name to clarify brand.

For Just Pi Zero 2 W instructions:

Corrected purchase link for Raspberry Pi Official USB-Micro Power Supply