### PR TITLE
3d_printing.md: Fix link for one DIY case

### DIFF
--- a/docs/3d_printing.md
+++ b/docs/3d_printing.md
@@ -11,7 +11,7 @@
 | Model | Notes |
 |-------|-------|
 | https://www.thingiverse.com/thing:4799094 | Case for the [USB-C/PWR Splitter without Barrel jack](https://www.tindie.com/products/8086net/usb-cpwr-splitter/) |
-| https://www.thingiverse.com/thing:4931970 | Case for the [USB-C/PWR Splitter without Barrel jack](https://www.tindie.com/products/8086net/usb-cpwr-splitter/) |
+| https://www.thingiverse.com/thing:4931970 | Raspberry Pi 4 Pi-KVM Case |
 | https://www.thingiverse.com/thing:4862304 | Case for PiKVM (LCD + ATX) |
 | https://www.thingiverse.com/thing:4868258 | R4C3R - Low Profile PCIe bracket for PiKVM based on Raspberry Pi Zero + Lusya + ATX controls |
 | https://www.thingiverse.com/thing:4866005 | R4C3R - Full Profile PCIe bracket for PiKVM based on Raspberry Pi Zero + Lusya + ATX controls |


### PR DESCRIPTION
It's not a case for the USB-C/PWR splitter