### PR TITLE
Update ipmi.md to point to Dan Farmer's page on IPMI vs dead link

### DIFF
--- a/docs/ipmi.md
+++ b/docs/ipmi.md
@@ -7,7 +7,7 @@
 
 !!! warning
     Although PiKVM supports the IPMI protocol, we strongly recommend that you **DO NOT USE IT** outside of trusted networks
-    due to the protocol's [insecurity](https://github.com/NitescuLucian/nliplace.com.blog.drafts).
+    due to the protocol's [insecurity](http://fish2.com/ipmi/).
 
     Please consider to using the Redfish or [KVMD API](api.md) instead of it.
 


### PR DESCRIPTION
The docs linked to a dead page for IPMI insecurity; I couldn't find the original reference, but Dan Farmer has done a ton of excellent research into IPMI as a protocol and it's fundamental weaknesses (RAKP+ leaking hashes, cipher zero bypass, etc.).