### PR TITLE
Convert H1 to front matter in the rest of the help pages

### DIFF
--- a/docs/3d_printing.md
+++ b/docs/3d_printing.md
@@ -1,4 +1,7 @@
-# Cases for 3D printing
+---
+title: Cases for 3D printing
+description: Download and 3D-print your own case for a PiKVM
+---
 
 ## PiKVM V3 HAT cases
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,6 +1,6 @@
 ---
 title: HTTP API reference
-#description: Getting started with PiKVM V4 Mini & Plus
+description: Documentation for all functions of PiKVM microservices exposed via RESTful APIs
 ---
 
 This document describes the PiKVM API. Since the system consists of microservices, here is a common API with a common entry point provided by Nginx. The below examples use `curl` and [`websocat`](https://github.com/vi/websocat) with the `-k` option disables SSL certificate verification, since the self-signed certificateis are used in the default installation.
@@ -83,7 +83,7 @@ There are two options here:
 -----
 ## WebSocket events
 
-Most of the data during the user's work with pikvm is transmitted over WebSocket. This includes mouse events, keyboard input, change the state of the various subsystems (such as ATX and Mass Storage Drive). Each event type will be described in the corresponding paragraph for its component. When connecting via WebSocket, the client receives current states as separate events. Then, as the states change, it will receive new events.
+Most of the data during the user's work with PiKVM is transmitted over WebSocket. This includes mouse events, keyboard input, and changing the state of the various subsystems (such as ATX and Mass Storage Drive). Each event type will be described in the corresponding paragraph for its component. When connecting via WebSocket, the client receives current states as separate events. Then, as the states change, it will receive new events.
 
 In a normal situation, opening a socket session triggers the video streamer to start. The streamer works as long as there is at least one client connected via WebSocket. After the last connection is closed and the client timeout expires, the streamer will also be terminated.
 

--- a/docs/atx_board.md
+++ b/docs/atx_board.md
@@ -1,4 +1,7 @@
-# ATX control board
+---
+title: ATX control board
+desription: How to connect the ATX board to a PiKVM
+---
 
 To manage the power of your computer, you will need to install an ATX adapter board inside the case and connect it to the motherboard. There is a female to female ribbon cable that goes from the motherboard to the ATX adapter board and a male to female ribbon cable that goes from the adapter board to the front panel ribbon cable. There are two rows of pins on the ATX adapter board, it does not matter which ribbon cable is attached to which row. The columns must line up from the front panel through the ATX adapter to the motherboard.
 

--- a/docs/audio.md
+++ b/docs/audio.md
@@ -1,4 +1,7 @@
-# PiKVM V3+ two-way audio
+---
+title: PiKVM V3+ two-way audio
+description: How to setup two-way audio on PiKVM V3+
+---
 
 Official [PiKVM V3](v3.md) and [PiKVM V4 Mini/Plus](v4.md) devices have an exclusive audio transmission feature,
 including **two-way** communication with microphone directly in the browser.

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -1,4 +1,7 @@
-# Authentication
+---
+title: "Authentication"
+description: Regular and 2FA authentication on PiKVM
+---
 
 !!! warning "PiKVM comes with the following default passwords"
 

--- a/docs/bluetooth_hid.md
+++ b/docs/bluetooth_hid.md
@@ -1,4 +1,7 @@
-# Bluetooth HID
+---
+title: Bluetooth HID
+description: How to configure PiKVM to emulate a Bluetooth keyboard & mouse
+---
 
 PiKVM is able to emulate a Bluetooth keyboard & mouse.
 This is not the main case of using PiKVM since you still need it to pair with a remote host, but can be used for something like mobile KVM.

--- a/docs/building_os.md
+++ b/docs/building_os.md
@@ -1,4 +1,7 @@
-# Building PiKVM OS
+---
+title: Building PiKVM OS
+description: How to build PiKVM OS from source code with Docker
+---
 
 The assembly of PiKVM OS is carried out using a special build environment.
 Here the minimum required for its use, imposed on the build machine:

--- a/docs/cloudflared.md
+++ b/docs/cloudflared.md
@@ -1,4 +1,7 @@
-# Cloudflare Tunnels
+---
+title: Cloudflare tunnels
+description: How to configure Cloudflare tunnels for your PiKVM
+---
 
 !!! warning
 	This is unofficial instructions proposed by the community. We don't officially support this and don't know what problems may arise when using cloudflared.

--- a/docs/edid.md
+++ b/docs/edid.md
@@ -1,4 +1,7 @@
-# EDID
+---
+title: EDID
+description: How to manipulate the EDID information on your PiKVM
+---
 
 !!! info
 

--- a/docs/ezcoo.md
+++ b/docs/ezcoo.md
@@ -1,11 +1,20 @@
-# ezCoo managed multiport KVM switch
+---
+title: ezCoo managed multiport KVM switch
+description: The ezCoo managed switch can be controlled by PiKVM to allow it to connect to multiple hosts
+---
 
 !!! warning
     While we provide this document for your convenience, this is a third-party hardware device in the same path as a PiKVM. Therefore, you may need to experiment (trial and error) to get it to work how you like. In the case of the U3P (hot key version), it may or may not work as expected.
 
 {!_multiport_usb.md!}
 
-The ezCoo managed switch can be controlled by PiKVM to allow it to connect to multiple hosts. A typical scenario is a single PiKVM device which can control and switch between multiple hosts or servers using the ezCoo switch. UI elements can be added to the [GPIO dropdown](gpio.md) to allow switching between hosts from the PiKVM webpage. The instructions here were tested with the ~~[ezCoo SW41HA HDMI 4x1 switch](https://www.easycoolav.com/products/hdmi20-switch-4x1-with-usb20-kvm-4-port-usbsupport-4k60hz-444-and-hdr-audio-breakout)~~ [ezCoo EZ-SW41HA-KVMU3L 4x1 switch](https://www.easycoolav.com/products/hdmi20-switch-4x1-with-usb30-kvm-3-port-usbsupport-4k60hz-444-and-hdr-audio-breakout-36) OR [ezCoo EZ-SW41HA-KVMU3P 4x1 switch](https://www.amazon.com/gp/product/B09ZKZK7ZB). Both older USB2.0 and newer USB3.0 variants are supported. The following was testing on a Raspberry Pi 4 but should also work on the Pi 2 and 3. This document was created using the contributions from multiple users in our [Discord](https://discord.gg/bpmXfz5) and the author appreciates their efforts.
+The ezCoo managed switch can be controlled by PiKVM to allow it to connect to multiple hosts. A typical scenario is a single PiKVM device which can control and switch between multiple hosts or servers using the ezCoo switch. UI elements can be added to the [GPIO dropdown](gpio.md) to allow switching between hosts from the PiKVM webpage.
+
+The instructions here were tested with the ~~[ezCoo SW41HA HDMI 4x1 switch](https://www.easycoolav.com/products/hdmi20-switch-4x1-with-usb20-kvm-4-port-usbsupport-4k60hz-444-and-hdr-audio-breakout)~~ [ezCoo EZ-SW41HA-KVMU3L 4x1 switch](https://www.easycoolav.com/products/hdmi20-switch-4x1-with-usb30-kvm-3-port-usbsupport-4k60hz-444-and-hdr-audio-breakout-36) OR [ezCoo EZ-SW41HA-KVMU3P 4x1 switch](https://www.amazon.com/gp/product/B09ZKZK7ZB).
+
+Both older USB2.0 and newer USB3.0 variants are supported. The following was testing on a Raspberry Pi 4 but should also work on the Pi 2 and 3.
+
+This document was created using the contributions from multiple users in our [Discord](https://discord.gg/bpmXfz5) and the author appreciates their efforts.
 
 !!! info
     While most images of the switch do not show the sides, there is a Micro USB port on the side of the ezCoo switch. This is the management port, which is controlled via COM port on the ezCoo KVM. When plugged into the Raspberry Pi, it appears as `/dev/ttyUSB0`.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,6 +1,11 @@
-# FAQ & Troubleshooting
+---
+title: FAQ & Troubleshooting
+description: Frequently asked questions and troubleshooting for your PiKVM
+---
 
-As a first step, we recommend carefully reading our documentation on [GitHub](https://github.com/pikvm/pikvm) or the updated [documentation](https://docs.pikvm.org). Most steps to successfully set up your PiKVM are already described there. If you run into any issues you can check this page which will list common errors. If that still doesn't help you you're welcome to raise an [issue ticket](https://github.com/pikvm/pikvm/issues) or [join our Discord](https://discord.gg/bpmXfz5) for further help.
+As a first step, we recommend carefully reading our documentation on [GitHub](https://github.com/pikvm/pikvm) or the updated [documentation](https://docs.pikvm.org). Most steps to successfully set up your PiKVM are already described there.
+
+If you run into any issues you can check this page which will list common errors. If that still doesn't help you you're welcome to raise an [issue ticket](https://github.com/pikvm/pikvm/issues) or [join our Discord](https://discord.gg/bpmXfz5) for further help.
 
 
 ## Common questions

--- a/docs/flashing_os.md
+++ b/docs/flashing_os.md
@@ -1,4 +1,7 @@
-# Flashing PiKVM OS image
+---
+title: Flashing PiKVM OS image
+description: How to flash a PiKVM OS image to an SD card
+---
 
 !!! warning "Micro-SD Card Requirements"
 

--- a/docs/gpio.md
+++ b/docs/gpio.md
@@ -1,4 +1,7 @@
-# GPIO
+---
+title: GPIO
+description: "How to use GPIO on a PiKVM: drivers, configuration, modules, and more"
+---
 
 [GPIO (general-purpose input/output)](https://en.wikipedia.org/wiki/General-purpose_input/output) is a series of digital interfaces that can be used to connect relays, LEDs, sensors, and other components.
 

--- a/docs/id.md
+++ b/docs/id.md
@@ -1,7 +1,12 @@
-# Identifying PiKVM on the target host
+---
+title: Identifying PiKVM on the target host
+description: How PiKVM is presented to the target host's operating system, and how this can be changed
+---
 
-This page explains how PiKVM is presented to the target host's operating system, and how this can be changed.
-This is useful for developers, testers and system administrators who need PiKVM to emulate a specific USB device or monitor.
+This page explains how PiKVM is presented to the target host's operating
+system, and how this can be changed. This is useful for developers,
+testers and system administrators who need PiKVM to emulate a specific
+USB device or monitor.
 
 !!! info
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,10 +1,14 @@
-# PiKVM Handbook
+---
+title: PiKVM Handbook
+description: Comprehensive guide to configuring and using your PiKVM
+---
 
-**Welcome to the [PiKVM](https://pikvm.org) Handbook** - a complete documentation of the Open Source KVM over IP on Raspberry Pi!
+**Welcome to the [PiKVM](https://pikvm.org) Handbook**—a complete
+documentation of the Open-Source KVM-over-IP on Raspberry Pi!
 
-Here you will find comprehensive information about all aspects of the operation of PiKVM, get answers to your most difficult questions
-and be able to solve the problems that have arisen.
-
+Here you will find comprehensive information about all aspects of the
+operation of PiKVM, get answers to your most difficult questions and be
+able to solve the problems that have arisen.
 
 ## Where to start?
 

--- a/docs/ipmi.md
+++ b/docs/ipmi.md
@@ -1,4 +1,7 @@
-# IPMI & Redfish
+---
+title: IPMI & Redfish
+description: How to use IPMI and Redfish for remote PiKVM management
+---
 
 !!! info
     This page is about the server-side IPMI emulation if you want to manage PiKVM using `ipmitool` or something similar.

--- a/docs/letsencrypt.md
+++ b/docs/letsencrypt.md
@@ -1,9 +1,15 @@
-# Let's Encrypt certificates
+---
+title: Let's Encrypt certificates
+description: How to use Let's Encrypt certificates instead of the default self-signed SSL certificates on your PiKVM
+---
 
-PiKVM uses self-signed SSL certificates out of the box. If you have a domain name, you can use Let's Encrypt certificates.
+PiKVM uses self-signed SSL certificates out of the box. If you have a
+domain name, you can use Let's Encrypt certificates.
 
-Usually Let's Encrypt certificates are issued and updated automatically using Certbot, however, since PiKVM uses a read-only
-file system, special tools around Certbot are required to work with certificates. KVMD 3.117 provides them.
+Usually Let's Encrypt certificates are issued and updated automatically
+using Certbot, however, since PiKVM uses a read-only file system,
+special tools around Certbot are required to work with certificates.
+KVMD 3.117 provides them.
 
 !!! note
     This feature is available on images as old as 2022.06.19 since it requires [PST storage partition on SD card](pst.md).

--- a/docs/modem.md
+++ b/docs/modem.md
@@ -1,16 +1,17 @@
-# Setting up 3G/4G/LTE modem
+---
+title: Setting up 3G/4G/LTE modem
+description: How to configure a 3G/4G/LTE modem to connect to Internet without a permanent wired network access
+---
 
-With PiKVM, you can create a portable device to work in a distant environment without
-a permanent wired internet connection. A cellular modem in combination with any VPN
-like [Tailscale](tailscale.md) is also an excellent backup for emergency access to the host.
-
+With PiKVM, you can create a portable device to work in a distant
+environment without a permanent wired internet connection. A cellular
+modem in combination with any VPN like [Tailscale](tailscale.md) is also
+an excellent backup for emergency access to the host.
 
 -----
 ## Choosing a modem
 
-PiKVM supports a huge number of USB modems.
-If the modem works with a desktop Linux, it will work with PiKVM as well.
-
+PiKVM supports a huge number of USB modems. If the modem works with a desktop Linux, it will work with PiKVM as well.
 
 ### Mini-PCI on PiKVM V4 Plus
 

--- a/docs/mouse.md
+++ b/docs/mouse.md
@@ -1,4 +1,7 @@
-# Mouse
+---
+title: Mouse
+description: How to use the absolute, relative, and dual modes for your mouse on a PiKVM
+---
 
 There are two modes of pointer device: absolute and relative.
 

--- a/docs/mouse_jiggler.md
+++ b/docs/mouse_jiggler.md
@@ -1,4 +1,7 @@
-# Mouse Jiggler
+---
+title: Mouse Jiggler
+description: How to configure and use mouse jiggler to simulate the movement of a computer mouse
+---
 
 The mouse jiggler is a feature used to simulate the movement of a computer mouse.
 It prevents sleep mode, standby mode or the screensaver from activating.

--- a/docs/msd.md
+++ b/docs/msd.md
@@ -1,4 +1,7 @@
-# Mass Storage Drive
+---
+title: Mass Storage Drive
+description: Mass storage drive allows PiKVM to emulate a virtual CD/DVD or Flash Drive for the target host
+---
 
 This powerful feature that is available on all PiKVM V2+ devices.
 It allows PiKVM to emulate a virtual CD/DVD or Flash Drive for the target host

--- a/docs/msd_legacy.md
+++ b/docs/msd_legacy.md
@@ -1,4 +1,7 @@
-# Big DVD images on old PiKVM
+---
+title: Big DVD images on old PiKVM
+description: If you need to emulate DVD images on an old PiKVM, here is how you can do it
+---
 
 Since KVMD 4.49, PiKVM is able to emulate DVD images.
 

--- a/docs/multiport.md
+++ b/docs/multiport.md
@@ -1,5 +1,7 @@
-# Multiport KVM over IP
-
+---
+title: Multiport KVM-over-IP
+description: If you need to connect multiple hosts to a single PiKVM, your options are PiKVM Switch and a number of 3rd-party KVMs
+---
 
 ??? note
     V4 MINI can ONLY be used with the TESmart or other KVMs with LAN control, the TESmart has a convenience driver for easier setup
@@ -7,8 +9,7 @@
 
 <img src="../switch/switch.png" width="400" />
 
-If you need to connect multiple hosts to a single PiKVM, then the best way to do this is to use our [Pikvm Switch](switch.md).
-It is designed specifically for PiKVM and has many advantages and features compared to regular desktop multiport switches.
+If you need to connect multiple hosts to a single PiKVM, then the best way to do this is to use our [PiKVM Switch](switch.md). It is designed specifically for PiKVM and has many advantages and features compared to regular desktop multiport switches.
 
 * ATX control on each port.
 * Per-port EDID configuration.

--- a/docs/ocr.md
+++ b/docs/ocr.md
@@ -1,8 +1,14 @@
-# OCR
+---
+title: OCR
+description: How to install optical character recognition data for Tesseract
+---
 
-This feature allows you to select a screen region, recognize it as text and copy this text to the clipboard.
-Recognition works locally on your PiKVM and does not use any cloud services. It uses the [Tesseract OCR library](https://github.com/tesseract-ocr/tesseract).
-Tesseract does not see your image until you explicitly give the recognition command. The evil AI is not watching your screen.
+This feature allows you to select a screen region, recognize it as text
+and copy this text to the clipboard. Recognition works locally on your
+PiKVM and does not use any cloud services. It uses the [Tesseract OCR
+library](https://github.com/tesseract-ocr/tesseract). Tesseract does not
+see your image until you explicitly give the recognition command. The
+evil AI is not watching your screen.
 
 ## Language support
 

--- a/docs/on_boot_config.md
+++ b/docs/on_boot_config.md
@@ -1,14 +1,19 @@
-# On-boot configuration & production deployment
+---
+title: On-boot configuration & production deployment
+description: How to configure parameters that are applied the first time a PiKVM is booted
+---
 
-At the first boot, PiKVM generates encryption keys and performs other actions necessary to configure the device.
+At the first boot, PiKVM generates encryption keys and performs other
+actions necessary to configure the device.
 
-Some parameters, such as connecting to Wi-Fi, or configuring a static interface for wired Ethernet,
-can be easily changed by the user if there is physical access to the memory card.
-This is convenient for quick customization of your device before the first use.
+Some parameters, such as connecting to Wi-Fi, or configuring a static
+interface for wired Ethernet, can be easily changed by the user if there
+is physical access to the memory card. This is convenient for quick
+customization of your device before the first use.
 
-All settings are made using a file `pikvm.txt` on the first section of the memory card.
-After applying the settings, the file is automatically deleted.
-
+All settings are made using a file `pikvm.txt` on the first section of
+the memory card. After applying the settings, the file is automatically
+deleted.
 
 -----
 ## Setting up Wi-Fi

--- a/docs/pico_hid.md
+++ b/docs/pico_hid.md
@@ -1,5 +1,7 @@
-# The Pico HID
-
+---
+title: The Pico HID
+description: How to perform keyboard and mouse emulation on DIY PiKVM V1 with Pico HID
+---
 
 !!! tip "A fast way to get PS/2 on PiKVM V2+"
     If you need PS/2 keyboard & mouse on [PiKVM V2](v2.md), [V3](v3.md) and [V4 Plus](v4.md)
@@ -11,8 +13,10 @@
     (the first model) based on RP2040 microcontroller is required.
     Pico 2 is not supported right now.
 
-The Pico HID is a part of [DIY PiKVM V1](v1.md) platform that performs keyboard and mouse emulation.
-It has excellent compatibility, and emulates USB by default, including two mouse modes: absolute and relative.
+The Pico HID is a part of [DIY PiKVM V1](v1.md) platform that performs
+keyboard and mouse emulation. It has excellent compatibility, and
+emulates USB by default, including two mouse modes: absolute and
+relative.
 
 Full list of features:
 

--- a/docs/pico_hid_bridge.md
+++ b/docs/pico_hid_bridge.md
@@ -1,4 +1,7 @@
-# The Pico HID - PS/2 Bridge
+---
+title: The Pico HID - PS/2 Bridge
+description: How to use a special version of the generic Pico HID to emulate a PS/2 keyboard and mouse emulator on DIY PiKVM V1
+---
 
 !!! note "Pico requirements"
     [Raspberri Pi Pico](https://www.raspberrypi.com/products/raspberry-pi-pico/)

--- a/docs/port_forwarding.md
+++ b/docs/port_forwarding.md
@@ -1,9 +1,12 @@
-# Port forwarding
+---
+title: Port forwarding
+description: How to setup port forwarding to make your PiKVM accessible from Internet
+---
 
-If you need to make PiKVM accessible from Internet,
-the easiest way to achieve this is by forwarding a port on the router.
-In this case, an external (global) IP address must be assigned to the router.
-This service is provided by the ISP.
+If you need to make PiKVM accessible from Internet, the easiest way to
+achieve this is by forwarding a port on the router. In this case, an
+external (global) IP address must be assigned to the router. This
+service is provided by the ISP.
 
 !!! tip
     If using an external IP address is not possible, it is recommended to try

--- a/docs/prometheus.md
+++ b/docs/prometheus.md
@@ -1,8 +1,14 @@
-# Prometheus metrics
+---
+title: Prometheus metrics
+description: How to configure Prometheus to monitor your PiKVM metrics
+---
 
-[Prometheus](https://prometheus.io) is one of the popular monitoring systems.
-It pulls service's endpoint to get metrics in a [simple text format](https://prometheus.io/docs/instrumenting/exposition_formats).
-PiKVM has the ability to export some information to this system such as the server's ATX state, Pi's temperature, [GPIO](gpio.md) state and some other things.
+[Prometheus](https://prometheus.io) is one of the popular monitoring
+systems. It pulls service's endpoint to get metrics in a [simple text
+format](https://prometheus.io/docs/instrumenting/exposition_formats).
+PiKVM has the ability to export some information to this system such as
+the server's ATX state, Pi's temperature, [GPIO](gpio.md) state and some
+other things.
 
 
 ## Configure Prometheus

--- a/docs/pst.md
+++ b/docs/pst.md
@@ -1,15 +1,22 @@
-# Persistent storage
+---
+title: Persistent storage
+description: How to use the 256MiB partition on your PiKVM to store data
+---
 
 !!! note
     This feature is available on images newer than 2022.06.20
 
-Sometimes advanced use of PiKVM requires storing some data on disk like API keys, config files, or something like that.
-For example, you want to have a script that will update SSL certificates once a week.
-However, the root file system is in a read-only state and does not involve remounting automatically by user scripts.
+Sometimes advanced use of PiKVM requires storing some data on disk like
+API keys, config files, or something like that. For example, you want to
+have a script that will update SSL certificates once a week. However,
+the root file system is in a read-only state and does not involve
+remounting automatically by user scripts.
 
-To solve this problem, new versions of PiKVM have a small 256MiB storage partition that can be used to store that data.
-A special `kvmd-pst` daemon makes sure that this partition is mounted in read-only all the time, and remounts it to RW
-only when some user script requires it. This also solves the problems of simultaneous access, so the RW mode will be
+To solve this problem, new versions of PiKVM have a small 256MiB storage
+partition that can be used to store that data. A special `kvmd-pst`
+daemon makes sure that this partition is mounted in read-only all the
+time, and remounts it to RW only when some user script requires it. This
+also solves the problems of simultaneous access, so the RW mode will be
 kept as long as at least one client is working with the storage.
 
 

--- a/docs/reverse_proxy.md
+++ b/docs/reverse_proxy.md
@@ -1,7 +1,11 @@
-# Reverse Proxy
+---
+title: Reverse proxy
+description: How to configure a reverse proxy on your PiKVM
+---
 
-A reverse proxy allows you to pass requests through your web server to another site or program.
-The reverse proxy will make it look like PiKVM Web UI is a page within your existing site.
+A reverse proxy allows you to pass requests through your web server to
+another site or program. The reverse proxy will make it look like PiKVM
+Web UI is a page within your existing site.
 
 This is especially useful if:
 

--- a/docs/tailscale.md
+++ b/docs/tailscale.md
@@ -1,11 +1,16 @@
-# Tailscale VPN
+---
+title: Tailscale VPN
+description: How to configure the access to your PiKVM using Tailscale VPN
+---
 
-The [Tailscale VPN](https://tailscale.com/) can be used to access PiKVM from the Internet
-if configuring [port forwarding](port_forwarding.md) is not possible or more security is desired.
-Tailscale is a convenient and free (for private use) tool for organizing a small VPN network.
+The [Tailscale VPN](https://tailscale.com/) can be used to access PiKVM
+from the Internet if configuring [port forwarding](port_forwarding.md)
+is not possible or more security is desired. Tailscale is a convenient
+and free (for private use) tool for organizing a small VPN network.
 
-The basic Tailscale configuration commands are shown below.
-For detailed instructions, refer to [Tailscale support](https://tailscale.com/contact/support/).
+The basic Tailscale configuration commands are shown below. For detailed
+instructions, refer to [Tailscale
+support](https://tailscale.com/contact/support/).
 
 -----
 

--- a/docs/tesmart.md
+++ b/docs/tesmart.md
@@ -1,6 +1,19 @@
-# TESMART managed multiport KVM switch
+---
+title: TESMART managed multiport KVM switch
+description: How to control the TESMART managed switch with PiKVM to allow the switch to connect to multiple hosts
+---
 
-The TESMART managed switch can be controlled by PiKVM to allow it to connect to multiple hosts. A typical scenario is a single PiKVM device which can control and switch between multiple hosts or servers using the TESMART switch. UI elements can be added to the [GPIO dropdown](gpio.md) to allow switching between hosts from the PiKVM webpage. The instructions here were tested with the [TESMART HKS1601A10 HDMI 16x1 switch](https://www.amazon.com/dp/B07D2ZMF5B ). This should work with any of the other TESMART variants which have a LAN port - there is both a 8x1 and 4x1 variant.  This was tested with an RPI4, but as this is executed over a network protocol, this should with almost anything.
+The TESMART managed switch can be controlled by PiKVM to allow it to
+connect to multiple hosts. A typical scenario is a single PiKVM device
+which can control and switch between multiple hosts or servers using the
+TESMART switch. UI elements can be added to the [GPIO dropdown](gpio.md)
+to allow switching between hosts from the PiKVM webpage.
+
+The instructions here were tested with the [TESMART HKS1601A10 HDMI 16x1
+switch](https://www.amazon.com/dp/B07D2ZMF5B ). This should work with
+any of the other TESMART variants which have a LAN port - there is both
+a 8x1 and 4x1 variant.  This was tested with an RPI4, but as this is
+executed over a network protocol, this should with almost anything.
 
 
 ## Connections

--- a/docs/usb.md
+++ b/docs/usb.md
@@ -1,14 +1,22 @@
-# USB configuration
+---
+title: USB configuration
+description: How USB works on the PiKVM, what endpoints are available, and how to configure it
+---
 
-PiKVM V2+ emulates a small set of USB devices to ensure normal operation: a keyboard, [mouse](mouse.md) and [mass storage drive](msd.md).
-However, the possibilities are not limited to this. Optionally, you can add a [USB ethernet](usb_ethernet.md),
-[serial port](usb_serial.md), or (exclusive to [PiKVM V3](v3.md) and [V4 Mini/Plus](v4.md)) [a microphone to support two-way audio](audio.md).
+PiKVM V2+ emulates a small set of USB devices to ensure normal
+operation: a keyboard, [mouse](mouse.md) and [mass storage
+drive](msd.md). However, the possibilities are not limited to this.
+Optionally, you can add a [USB ethernet](usb_ethernet.md), [serial
+port](usb_serial.md), or (exclusive to [PiKVM V3](v3.md) and [V4
+Mini/Plus](v4.md)) [a microphone to support two-way audio](audio.md).
 
-In rare cases, the target host's BIOS/UEFI may not understand such a large number of emulated devices on single USB port,
-and some of them may need to be disabled.
+In rare cases, the target host's BIOS/UEFI may not understand such a
+large number of emulated devices on single USB port, and some of them
+may need to be disabled.
 
-A complete USB configuration changing (adding or removing devices) requires a reboot, but it is possible
-to temporarily disable and then re-enable existing emulated devices in preset.
+A complete USB configuration changing (adding or removing devices)
+requires a reboot, but it is possible to temporarily disable and then
+re-enable existing emulated devices in preset.
 
 
 -----
@@ -61,9 +69,10 @@ For information on how emulated devices are represented on the target host and h
 
 Device setup includes two stages: adding to config and starting.
 
-When you add a device as described on the pages above, it automatically turns on after PiKVM reboot
-and becomes available on the target device. This behaviour can be changed: the device will be created,
-but not active until you turn it on dynamically.
+When you add a device as described on the pages above, it automatically
+turns on after PiKVM reboot and becomes available on the target device.
+This behaviour can be changed: the device will be created, but not
+active until you turn it on dynamically.
 
 The `/etc/kvmd/override.yaml` file is used for such changes. In the following example,
 there are [USB Serial Port](usb_serial.md) and [Microphone](audio.md) enabled,

--- a/docs/usb_ethernet.md
+++ b/docs/usb_ethernet.md
@@ -1,4 +1,7 @@
-# Ethernet-over-USB network
+---
+title: Ethernet-over-USB network
+description: How to configure a Ethernet-over-USB network on PiKVM V2+
+---
 
 Specifically to PiKVM V2+. When combined with configuring a DNS server, FTP, or SMB (for example), this is a powerful way to extend the capabilities of PiKVM.
 
@@ -73,7 +76,6 @@ Specifically to PiKVM V2+. When combined with configuring a DNS server, FTP, or 
 3. To enable the service, use the command `systemctl enable kvmd-otgnet`.
 
 4. Perform `reboot`.
-
 
 ## Routing via PiKVM
 

--- a/docs/usb_serial.md
+++ b/docs/usb_serial.md
@@ -1,4 +1,7 @@
-# Serial-over-USB connection
+---
+title: Serial-over-USB connection
+description: How to configure a serial-over-USB connection on PiKVM V2+
+---
 
 Specifically to V2+. This can be used for terminal access from the target host to the PiKVM, or for any other purpose that requires a serial connection. In the last case, you only need to perform step 1 and reboot.
 

--- a/docs/video.md
+++ b/docs/video.md
@@ -1,10 +1,18 @@
+---
+title: Video modes
+description: Key differences between available video modes on PiKVM and tips for using them
+---
+
 # Video modes
 
-PiKVM [V3](v3.md), [V4 Plus/Mini](v4.md) and all DIY devices based on HDMI-CSI bridge provides three video streaming modes.
-This page explains the key differences between them and helps you to achieve optimal video performance.
+PiKVM [V3](v3.md), [V4 Plus/Mini](v4.md) and all DIY devices based on
+HDMI-CSI bridge provides three video streaming modes. This page explains
+the key differences between them and helps you to achieve optimal video
+performance.
 
-The video mode can be switched in the **System** menu in the Web UI.
-If you don't see the switch, probably your browser does not support H.264 video.
+The video mode can be switched in the **System** menu in the Web UI. If
+you don't see the switch, probably your browser does not support H.264
+video.
 
 
 <img src="menu.png" width="350" />
@@ -34,10 +42,12 @@ If you don't see the switch, probably your browser does not support H.264 video.
 -----
 ## WebRTC H.264 mode
 
-This is the default mode. It'is using the efficient H.264 encoding to save traffic.
-The video is streamed over WebRTC protocol which you may have encountered when you used video calls in Discord or Google Chat.
-Since WebRTC does not use HTTP for video, establishing a connection is quite tricky (but PiKVM automates 99% of cases).
-If you have problems with the WebRTC mode, please [check this guide](webrtc_config.md).
+This is the default mode. It'is using the efficient H.264 encoding to
+save traffic. The video is streamed over WebRTC protocol which you may
+have encountered when you used video calls in Discord or Google Chat.
+Since WebRTC does not use HTTP for video, establishing a connection is
+quite tricky (but PiKVM automates 99% of cases). If you have problems
+with the WebRTC mode, please [check this guide](webrtc_config.md).
 
 !!! info "Advantages / Disadvantages"
 

--- a/docs/vnc.md
+++ b/docs/vnc.md
@@ -1,9 +1,17 @@
+---
+title: VNC
+description: How to enable and configure VNC for accessing your PiKVM
+---
+
 # VNC
 
-As an alternative to the Web UI, a regular VNC client can be used to access to the PiKVM.
-The main advantage of VNC over the browser is the ability to expand the image to the full screen,
-as well as complete interception of all keyboard shortcuts. In some cases, VNC will be more responsive
-than the browser, especially on weak client computers.
+As an alternative to the Web UI, a regular VNC client can be used to
+access to the PiKVM.
+
+The main advantage of VNC over the browser is the ability to expand the
+image to the full screen, as well as complete interception of all
+keyboard shortcuts. In some cases, VNC will be more responsive than the
+browser, especially on weak client computers.
 
 !!! warning
     Don't use VNC without X.509 or TLS encryption on untrusted networks!

--- a/docs/webrtc_config.md
+++ b/docs/webrtc_config.md
@@ -1,3 +1,8 @@
+---
+title: WebRTC H.264
+description: how to configure and troubleshoot the WebRTC H.264 streaming mode
+---
+
 # WebRTC H.264
 
 This is the default mode. It'is using the efficient H.264 encoding to save traffic.
@@ -12,21 +17,26 @@ If you don't see the switch, probably your browser does not support H.264 video.
 -----
 ## How it's working
 
-The [Direct H.264 or MJPEG video](video.md) is streaming video using the similar HTTP connection like to get the Web UI.
-This means that for remote access, you just need to [forward](port_forwarding.md) only ports `80` and `443` on your router it has public external IP address.
+The [Direct H.264 or MJPEG video](video.md) is streaming video using the
+similar HTTP connection like to get the Web UI. This means that for
+remote access, you just need to [forward](port_forwarding.md) only ports
+`80` and `443` on your router it has public external IP address.
 
 In contrast, WebRTC is a completely different way of transmitting video.
-It uses a P2P connection and UDP. This reduces network load, but makes it difficult to connect -
-the PiKVM needs to know your network configuration in order to use it correctly: public IP, NAT type and so on.
+It uses a P2P connection and UDP. This reduces network load, but makes
+it difficult to connect—the PiKVM needs to know your network
+configuration in order to use it correctly: public IP, NAT type and so
+on.
 
-To achieve this, the PiKVM checks which of the network interfaces is used for the default gateway,
-and tries to find out your external IP address using the Google [STUN](https://en.wikipedia.org/wiki/STUN) server.
+To achieve this, the PiKVM checks which of the network interfaces is
+used for the default gateway, and tries to find out your external IP
+address using the Google [STUN](https://en.wikipedia.org/wiki/STUN)
+server.
 
 !!! tip
     Google STUN servers was choosen for reliability reasons.
 
-    If you don't want to use it, you can choose [any other public STUN server](https://www.voip-info.org/stun)
-    you like, or set up your own.
+    If you don't want to use it, you can choose [any other public STUN server](https://www.voip-info.org/stun) you like, or set up your own.
 
     To change the STUN server, edit `/etc/kvmd/override.yaml` (an example):
 
@@ -43,21 +53,25 @@ and tries to find out your external IP address using the Google [STUN](https://e
 -----
 ## Custom Janus config
 
-[Janus](https://janus.conf.meetecho.com) is a WebRTC gateway that is used to transmit the video from [PiKVM uStreamer](https://github.com/pikvm/ustreamer).
-PiKVM has a special service named `kvmd-janus` which is a wrapper for Janus that monitors the network configuration and applies changes.
+[Janus](https://janus.conf.meetecho.com) is a WebRTC gateway that is
+used to transmit the video from [PiKVM
+uStreamer](https://github.com/pikvm/ustreamer). PiKVM has a special
+service named `kvmd-janus` which is a wrapper for Janus that monitors
+the network configuration and applies changes.
 
-However, if your PiKVM is not connected to the Internet and/or you want to use a custom Janus configuration,
-you should run the `kvmd-janus-static` service instead.
+However, if your PiKVM is not connected to the Internet and/or you want
+to use a custom Janus configuration, you should run the
+`kvmd-janus-static` service instead.
 
-The configuration is located in `/etc/kvmd/janus/janus.jcfg`.
-You can change all you need according to the [Janus Documentation](https://janus.conf.meetecho.com/docs/index.html),
-stop the `kvmd-janus` and start the `kvmd-janus-static` service:
+The configuration is located in `/etc/kvmd/janus/janus.jcfg`. You can
+change all you need according to the [Janus
+Documentation](https://janus.conf.meetecho.com/docs/index.html), stop
+the `kvmd-janus` and start the `kvmd-janus-static` service:
 
 ```
 [root@pikvm ~]# systemctl disable --now kvmd-janus
 [root@pikvm ~]# systemctl enable --now kvmd-janus-static
 ```
-
 
 -----
 ## Troubleshooting

--- a/docs/webui.md
+++ b/docs/webui.md
@@ -1,4 +1,9 @@
-## GETTING TO KNOW THE INTERFACE
+---
+title: Getting to know the web UI
+description: How to get started with using the web interface for your PiKVM
+---
+
+## Logging in
 
 After following the first steps document on setup, you will be presented with the following pages (Chrome is being used in the following examples)
 
@@ -14,8 +19,11 @@ Click Proceed
 
 <img src="Login.jpg" width="400" />
 
-This is where you fill in the login credentials, please be sure to review the first steps document first.
-This is also where you configure the 2FA token
+This is where you fill in the login credentials, please be sure to
+review the first steps document first. This is also where you configure
+the 2FA token.
+
+## Initial screen
 
 <img src="Portal.jpg" width="400" />
 
@@ -30,6 +38,8 @@ This is also where you configure the 2FA token
     7. These are links to the PiKVM project, current documentation and support (Discord)
     8. **NOT SHOWN**, in the lower left of the KVM screen is some information that when you mouse over, will let you know what they are for
 
+## Web UI toolbar
+
 <img src="Toolbar.jpg" />
 
 ??? note "Please expand to see what each number represents"
@@ -41,6 +51,8 @@ This is also where you configure the 2FA token
     5. This is where you can SEND text to the Target or using OCR, you can copy FROM the target, be mindful that OCR can make mistakes, please review before finalizing
     6. This is where you can find most Shortcuts (Windows only, for now) (Not editable)
     7. This is placed here to give you an idea what you can achieve if you make your own menu item
+
+## The System menu
 
 <img src="System.jpg" width="400" />
 
@@ -68,18 +80,26 @@ This is also where you configure the 2FA token
     3. ONLY for MJPEG mode
     4. ONLY for H.264 (WebRTC) mode
 
+## The ATX menu
+
 <img src="ATX.jpg" width="400" />
 
-1. This ONLY works if you have the hardware connected to the MB, otherwise will not work
+This ONLY works if you have the hardware connected to the MB, otherwise will not work
+
+## The Drive menu
 
 <img src="Drive.jpg" width="400" />
 
-1. This is where you can select the IMG or ISO's that are stored
+This is where you can select the IMG or ISO's that are stored
+
+## The Macro menu
 
 <img src="Macro.jpg" width="400" />
 
 1. Please read and understand this section
-2. This is where you can upload or Download your scripts
+2. This is where you can upload or download your scripts
+
+## The Text menu
 
 <img src="Text.jpg" width="400" />
 
@@ -87,10 +107,12 @@ This is also where you configure the 2FA token
     This is not like VNC/AnyDesk/TeamViewer as these are software solutions, this is a hardware solution therefor cannot change the behavior of the target system.
     This does not act like a clipboard
 
-1. This will allow you to paste text to the target system - Be mindful whats being pasted to the target and how
-2. This will allow you to ONLY copy text from the target - Be mindful that OCR will do its best to recognize text but may fail at it
+1. This will allow you to paste text to the target system—be mindful whats being pasted to the target and how.
+
+2. This will allow you to ONLY copy text from the target—be mindful that OCR will do its best to recognize text but may fail at it.
+
+## The Shortcuts menu
 
 <img src="Shortcuts.jpg" width="400" />
 
-1. This is an expanded view and shows the shortcuts for mostly Windows
-
+This is an expanded view and shows the shortcuts mostly for Windows.

--- a/docs/wifi.md
+++ b/docs/wifi.md
@@ -1,13 +1,18 @@
-# Setting up Wi-Fi
+---
+title: Setting up Wi-Fi
+description: Learn how to configure a Wi-Fi connection on your PiKVM to one or multiple networks
+---
 
 !!! tip
     * There is nothing more reliable than wired Ethernet, so it's better to use it. Wi-Fi with the steel case (on PiKVM V3 and V4) results in poor performance. But who are we to stop you... :)
     * Devices based on Raspberry Pi Zero 2 W does not support 5GHz Wi-Fi.
 
-The following describes how to setup a Wi-Fi connection.
-We recommend to do this while having a display and keyboard
-or a serial console connected directly to the Raspberry Pi as you will loose network connectivity once you connect to a Wi-Fi.
-Alternatively you can connect to the PiKVM via SSH. The built-in Web Terminal (available through the browser) should also work.
+The following describes how to setup a Wi-Fi connection. We recommend to
+do this while having a display and keyboard or a serial console
+connected directly to the Raspberry Pi as you will loose network
+connectivity once you connect to a Wi-Fi. Alternatively you can connect
+to the PiKVM via SSH. The built-in Web Terminal (available through the
+browser) should also work.
 
 !!! warning "Take a look at the easiest way"
     This guide describes how to manually set up a Wi-Fi. An easier way is to use [On-boot config](on_boot_config.md).
@@ -17,9 +22,9 @@ Alternatively you can connect to the PiKVM via SSH. The built-in Web Terminal (a
 -----
 ## Setting up Wi-Fi manually
 
-1. Make filesystem writable using `rw` command.
+1. Make filesystem writable using the `rw` command.
 
-2. Create Wi-Fi settings file `/etc/systemd/network/wlan0.network` with following content:
+2. Create the Wi-Fi settings file `/etc/systemd/network/wlan0.network` with the following content:
 
     ```ini
     [Match]

--- a/docs/wiring_examples.md
+++ b/docs/wiring_examples.md
@@ -1,6 +1,10 @@
-### Some example wiring setups
+---
+title: Some example wiring setups
+description: Learn how to wire your DIY PiKVM from these examples
+---
 
-# HDMI-CSI
+## HDMI-CSI
+
 <img src="csi_wiring.jpg" alt="drawing">
 
 List of items: (WARNING! Links may dissappear or no longer work, this just gives you an idea)
@@ -12,13 +16,16 @@ List of items: (WARNING! Links may dissappear or no longer work, this just gives
 - DisplayPort TO HDMI pigtail (Cable) (Pic is displayed wrong)
 - TARGET (Anything you want to control)
 
-# Another CSI example using the PCB splitter
+## Another CSI example using the PCB splitter
+
 <img src="csi_wiring_w_pcb_splitter.jpg" alt="drawing">
 
-# HDMI-USB
+## HDMI-USB
+
 <img src="usb_capture_wiring.jpg" alt="drawing">
 
-# Direct connect to target
+## Direct connect to target
+
 <img src="direct_connect_to_target.jpg" alt="drawing">
 
 Explanation of pic
@@ -29,5 +36,5 @@ Use case:
 - Testing to see if the splitter or cable is defective
 - Basic troubleshooting
 
-# EZCOO wiring example
+## EZCOO wiring example
 <img src="ezcoo_wiring.jpg" alt="drawing">

--- a/docs/wol.md
+++ b/docs/wol.md
@@ -1,3 +1,8 @@
+---
+title: Wake-on-LAN
+description: "How to use Wake-on-LAN with a server: a simplified method for one host and a GPIO method for multiple hosts"
+---
+
 # Wake-on-LAN
 
 ## Simplified method (one host)


### PR DESCRIPTION
The Material theme for MkDocs already uses the title field from the metadata to render an <h1/> element on pages, so let's just use proper front matter and add the descriptions while at that.