### PR TITLE
Fix embedded videos

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -69,9 +69,8 @@ plugins:
     - search:
         lang: en
     - mkdocs-video:
-        is_video: True
-        video_muted: True
-        video_controls: True
+        video_autoplay: false
+        video_controls: true
     - redirects:
         redirect_maps:
             "lte.md": "modem.md"


### PR DESCRIPTION
For some reason, mkdocs hates the documented `is_video: True` plugin parameter for mkdocs-video, so let's tweak params.