### PR TITLE
docs: fix various typos across the repo

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -3,7 +3,7 @@ title: HTTP API reference
 description: Documentation for all functions of PiKVM microservices exposed via RESTful APIs
 ---
 
-This document describes the PiKVM API. Since the system consists of microservices, here is a common API with a common entry point provided by Nginx. The below examples use `curl` and [`websocat`](https://github.com/vi/websocat) with the `-k` option disables SSL certificate verification, since the self-signed certificateis are used in the default installation.
+This document describes the PiKVM API. Since the system consists of microservices, here is a common API with a common entry point provided by Nginx. The below examples use `curl` and [`websocat`](https://github.com/vi/websocat) with the `-k` option disables SSL certificate verification, since the self-signed certificates are used in the default installation.
 
 There is a [third-party library](https://github.com/guanana/pikvm-lib) for using the PiKVM API. Please note that this is an unofficial library, so use it carefully.
 
@@ -627,7 +627,7 @@ $ curl -k -X POST \
     }⏎  
     ```
 
-### Move the mouse ppinter relatively
+### Move the mouse pointer relatively
 
 **Method**: `POST`
 

--- a/docs/cloudflared.md
+++ b/docs/cloudflared.md
@@ -6,12 +6,12 @@ description: How to configure Cloudflare tunnels for your PiKVM
 !!! warning
 	This is unofficial instructions proposed by the community. We don't officially support this and don't know what problems may arise when using cloudflared.
 
-[Cloudflare Tunnels](https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/) can be used to access PiKVM over the internet securely using Cloudflare Zero Trust with Cloudflared. This is a convenient and free (for 50 users) tool for allowing access to web services running on your internal network without port forwarding or IPv4/IPv6 compatability issues. This document is provided as an example for accessing your PiKVM over the internet but you can also use Zerotier/[Tailscale](tailscale.md)/*Insert XYZ VPN service here*. Basic support like whats shown below is provided as an example, any other setting or functionality needs to be redirected to the appropriate community.
+[Cloudflare Tunnels](https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/) can be used to access PiKVM over the internet securely using Cloudflare Zero Trust with Cloudflared. This is a convenient and free (for 50 users) tool for allowing access to web services running on your internal network without port forwarding or IPv4/IPv6 compatibility issues. This document is provided as an example for accessing your PiKVM over the internet but you can also use Zerotier/[Tailscale](tailscale.md)/*Insert XYZ VPN service here*. Basic support like whats shown below is provided as an example, any other setting or functionality needs to be redirected to the appropriate community.
 
 !!! note "If you get error 1033 / lookup localhost error"
     You might need to add `127.0.0.1 localhost` into your /etc/hosts file
 
-## Prequisites
+## Prerequisites
   
 1. A domain utilizing Cloudflare for DNS
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -5,7 +5,7 @@ description: Frequently asked questions and troubleshooting for your PiKVM
 
 As a first step, we recommend carefully reading our documentation on [GitHub](https://github.com/pikvm/pikvm) or the updated [documentation](https://docs.pikvm.org). Most steps to successfully set up your PiKVM are already described there.
 
-If you run into any issues you can check this page which will list common errors. If that still doesn't help you you're welcome to raise an [issue ticket](https://github.com/pikvm/pikvm/issues) or [contact our Suppor](https://pikvm.org/support/) for further help.
+If you run into any issues you can check this page which will list common errors. If that still doesn't help you you're welcome to raise an [issue ticket](https://github.com/pikvm/pikvm/issues) or [contact our Support](https://pikvm.org/support/) for further help.
 
 
 ## Common questions

--- a/docs/gpio.md
+++ b/docs/gpio.md
@@ -42,7 +42,7 @@ Setting up GPIO is considerably complex. The interface is divided into several l
 -----
 ## Drivers
 
-The first part of the configuration refers to the hardware layer, which defines which IO channels are used (standard GPIO pins of the Raspberry Pi, an USB relay, and so on). If you just want to use GPIO with the default settings you can skip to the next section [Scheme](#Scheme).
+The first part of the configuration refers to the hardware layer, which defines which IO channels are used (standard GPIO pins of the Raspberry Pi, a USB relay, and so on). If you just want to use GPIO with the default settings you can skip to the next section [Scheme](#Scheme).
 
 Each hardware input/output requires a individual driver configuration entry. Each driver has a type (which refers to the plugin that handles the communication between PiKVM and the hardware) and a unique name. This allows you to either can add multiple drivers of the same type with different settings or connect multiple USB HID relays.
 

--- a/docs/msd_legacy.md
+++ b/docs/msd_legacy.md
@@ -124,7 +124,7 @@ sudo cp windows.iso /media/XXX/ventoy
 sudo umount /dev/loopXX 
 # This is going to be different for everyone, please choose the same one you mounted earlier
 sudo losetup -d /dev/loopXX 
-# This may or may not work for everyone, if it doesnt work, skip and move forward#
+# This may or may not work for everyone, if it doesn't work, skip and move forward#
 ```
 
 ssh into the Ubuntu system (Or whatever OS you are using)


### PR DESCRIPTION
  Typos Fixed (7 total):

  1. api.md:630 - ppinter → pointer ("Move the mouse pointer relatively")
  2. api.md:6 - certificateis → certificates ("self-signed certificates are used")
  3. faq.md:8 - Suppor → Support ("contact our Support")
  4. cloudflared.md:9 - compatability → compatibility ("IPv4/IPv6 compatibility issues")
  5. cloudflared.md:14 - Prequisites → Prerequisites (section heading)
  6. msd_legacy.md:127 - doesnt → doesn't (comment: "if it doesn't work")
  7. gpio.md:45 - an USB → a USB (article correction: "a USB relay")