### PR TITLE
Fixed minor typo, added link to Pico 2 (which isn't usable yet)

### DIFF
--- a/docs/pico_hid.md
+++ b/docs/pico_hid.md
@@ -9,9 +9,9 @@ description: How to perform keyboard and mouse emulation on DIY PiKVM V1 with Pi
     you can use a faster and easier way: [The Pico HID Bridge](pico_hid_bridge.md).
 
 !!! note "Pico requirements"
-    [Raspberri Pi Pico](https://www.raspberrypi.com/products/raspberry-pi-pico/)
+    [Raspberry Pi Pico](https://www.raspberrypi.com/products/raspberry-pi-pico/)
     (the first model) based on RP2040 microcontroller is required.
-    Pico 2 is not supported right now.
+    [Pico 2](https://www.raspberrypi.com/products/raspberry-pi-pico-2/) is not supported right now.
 
 The Pico HID is a part of [DIY PiKVM V1](v1.md) platform that performs
 keyboard and mouse emulation. It has excellent compatibility, and


### PR DESCRIPTION
Fixed extremely minor typo I noticed, also added a hyperlink to the Raspberry Pi product page for the Pico 2 as there is for the Pico 1, for completeness' sake.