### PR TITLE
Update faq for changing hostname

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -331,7 +331,7 @@ If you run into any issues you can check this page which will list common errors
 
 ??? question "Can I have different hostnames for each of my PiKVMs?"
     Yes! And it's easy to do! Using a SSH session or the web terminal:
-    * Make sure you are root, run `rw` then run `hostnamectl set-hostname yournewhostname.domain`.
+    * `systemd-hostnamed` is finicky and can have issues with changing the hostname if it was started while the filesystem was read-only. It can then complain the file system is read-only even after you have made it rw. To work around this, make sure you are root, run `rw && systemctl restart systemd-hostnamed` then run `hostnamectl set-hostname yournewhostname.domain`.
     * Optional: edit `/etc/kvmd/meta.yaml` to alter the displayed hostname in the web UI.
     * Run `ro` and `reboot`.
 


### PR DESCRIPTION
I spent a while banging my head against the wall, trying to figure out why my call of `rw && hostnamectl set-hostname foo` would sometimes fail. (It is important that `foo` be different than current hostname here and in commands below, or `set-hostname` will short-circuit and not actually do anything.) The `hostnamectl` command would return:

```
Could not set static hostname: /etc/hostname is in a read-only filesystem.
Hint: use --transient option when /etc/machine-info or /etc/hostname cannot be modified (e.g. located in read-only filesystem).
```

I finally realized that I could reproduce the issue by restarting `systemd-hostnamed` in readonly mode, and then trying to make the change:

```
ro && systemctl restart systemd-hostnamed && rw && hostnamectl set-hostname foo
```

will always fail. While

```
ro && systemctl restart systemd-hostnamed && rw && systemctl restart systemd-hostnamed && hostnamectl set-hostname foo
```

will always succeed.

The issue is intermittent because the system will deactivate and restart `systemd-hostnamed` at times, and so the behavior seen depends on if the file system was `ro` or `rw` when that last happened.