### PR TITLE
Remove extra backtick in tailscale docs

### DIFF
--- a/docs/tailscale.md
+++ b/docs/tailscale.md
@@ -133,7 +133,7 @@ Here's the command that allows you to seamlessly run HTTPS proxy for your PiKVM:
 And if you want to stop tailscale from serving HTTPS, you can do this by running:
 ```console
 [root@pikvm ~]# tailscale serve --https=443 off
-````
+```
 
 ### Root cause
 Tailscale needs to refresh TLS certificates and write state under `/var/lib/tailscale`.  


### PR DESCRIPTION
Fixes a formatting issue due to an extra backtick in the docs.

<img width="939" height="665" alt="Screenshot 2026-03-22 at 5 12 18 PM" src="https://github.com/user-attachments/assets/89a3ffb8-c141-4ac4-8cc7-e5a4a8c5d863" />
