### PR TITLE
Docs: Create missing sock directory for NetBird

### DIFF
--- a/docs/netbird.md
+++ b/docs/netbird.md
@@ -44,6 +44,9 @@ copy of the state.
         cp -a /root/netbird-state/. /tmp/netbird-state/
     fi
 
+    # Create sock directory
+    mkdir /var/run/netbird
+
     # Bind mount over /var/lib/netbird so NetBird sees the writable copy
     mkdir -p /var/lib/netbird
     mountpoint -q /var/lib/netbird && umount /var/lib/netbird || true


### PR DESCRIPTION
**Issue**: 
The directory /var/run/netbird wasn't created before netbird@netbird service starts thus caused it fail
**Solution**: 
Added a line the overlay script to manually create the directory on startup