### PR TITLE
docs/msd: troubleshooting for hosts that don't detect the virtual drive (#581)

### DIFF
--- a/docs/msd.md
+++ b/docs/msd.md
@@ -380,6 +380,69 @@ The full list of options can be found by running `kvmd-otgmsd --help`.
 
 
 -----
+## When the host doesn't detect the virtual drive
+
+Some hosts refuse to detect or boot from the emulated drive even though a **physical** USB flash
+drive with the *same* image works. This has been reported for game consoles (for example the
+Xbox One recovery / _Offline System Update_, see [#581](https://github.com/pikvm/pikvm/issues/581))
+and occasionally for strict BIOS/UEFI firmware.
+
+The usual reason is that such hosts are pickier about *how* the drive presents itself on USB than
+a regular PC. The emulated drive can be tuned to look as much like an ordinary removable flash
+stick as possible. Try these one change at a time, reconnecting the drive (V3/V4:
+`System -> Connect Main USB` off/on) or rebooting the target host after each:
+
+* **Present it as a writable Flash drive, not a CD-ROM.** In the `Drive` menu set the media type
+  to `Flash` and enable the `Writable` switch. Console recovery images generally expect a writable
+  removable disk rather than a read-only optical drive.
+
+* **Give it a real-looking identity.** By default the gadget advertises itself as a generic Linux
+  composite device; you can make it impersonate an ordinary vendor's flash stick (see below).
+
+??? example "Step by step: Making the drive look like a plain USB stick"
+
+    1. Switch the filesystem to read-write mode:
+
+        ```console
+        [root@pikvm ~]# rw
+        ```
+
+    2. Edit `/etc/kvmd/override.yaml`:
+
+        ```yaml
+        otg:
+            vendor_id: 0x0781         # e.g. SanDisk; use any real vendor/product IDs
+            product_id: 0x5567
+            devices:
+                msd:
+                    default:
+                        cdrom: false      # Flash, not CD/DVD
+                        rw: true          # Writable
+                        removable: true   # Report as removable media (this is the default)
+                        stall: true       # Some hosts expect bulk-endpoint STALL; worth toggling
+                        inquiry_string:
+                            flash:
+                                vendor: SanDisk
+                                product: "Cruzer Blade"
+                                revision: "1.00"
+        ```
+
+    3. Reboot:
+
+        ```console
+        [root@pikvm ~]# reboot
+        ```
+
+!!! note "Known limitation"
+    PiKVM presents a single **composite** USB device (keyboard + mouse + mass storage on one
+    cable), whereas a physical flash drive is a lone single-function device. Some hosts dislike a
+    mass-storage function inside a composite gadget — this is the current best guess for the Xbox
+    case and cannot be changed by the options above. If you have such a device and can capture the
+    USB traffic (comparing a working physical stick against the PiKVM drive), please share it on
+    [#581](https://github.com/pikvm/pikvm/issues/581) — that is what is needed to pin it down.
+
+
+-----
 ## Disabling Mass Storage
 
 In rare cases, it may be necessary to disable Mass Storage emulation if the BIOS/UEFI


### PR DESCRIPTION
## What / why

Relates to #581 (Xbox One doesn't detect the virtual drive).

I looked into this on the kvmd side and don't believe there's a code defect: every
USB/SCSI attribute a picky host could object to (`cdrom`, `rw`, `removable`, `stall`,
`inquiry_string`, `vendor_id`/`product_id`, `usb_version`) is already a configurable option
mapped to the kernel's `f_mass_storage` configfs attributes. What's missing is **documentation**
pointing users at those knobs when a host won't detect the emulated drive — so this is a docs PR
rather than a code change.

## Change

Adds a **"When the host doesn't detect the virtual drive"** section to `docs/msd.md` covering:

- Presenting the drive as a writable Flash device (not a read-only CD-ROM), which is what console
  recovery images expect.
- Making the gadget impersonate an ordinary vendor's flash stick via `override.yaml`
  (`vendor_id`/`product_id`, `inquiry_string`, and the `stall` bulk-endpoint option).
- An honest **Known limitation** note: PiKVM presents a single *composite* gadget while a physical
  stick is a lone single-function device — the current best guess for the Xbox case, which the
  options above can't change — plus a request for a USB capture to actually pin it down.

It slots in right before the existing *Disabling Mass Storage* section (added in #1673), which
covers a related "host mishandles the composite HID+MSD gadget" scenario.

## Testing

Docs-only. Verified the embedded `override.yaml` parses and that every key/value used exists in
the kvmd config scheme (`otg.vendor_id`/`product_id`, `otg.devices.msd.default.{cdrom,rw,removable,stall,inquiry_string.flash.*}`).
I did not build the MkDocs site locally, so please sanity-check rendering of the new admonition/example block.

I don't own an Xbox, so the compatibility guidance itself is unverified on the actual console —
it's framed as "things to try," not a guaranteed fix. Happy to adjust wording/placement.
