### PR TITLE
audio: two-way audio in the direct video mode

### DIFF
--- a/docs/audio.md
+++ b/docs/audio.md
@@ -13,8 +13,8 @@ This brings the user experience of working with voice applications on the remote
 
     * Audio does not work with DIY devices, either CSI or USB video dongles.
 
-    * [VNC](vnc.md) does not support audio, it only works in the Web UI.
-        The speakers require the `WebRTC` video mode, the microphone works in the `Direct` mode too.
+    * [VNC](vnc.md) does not support audio, it only works in the Web UI,
+        in the `WebRTC` and `Direct` video modes.
 
 
 -----
@@ -56,9 +56,9 @@ PiKVM supports stereo mode with any standard bits and frequencies like 32/44.1/4
     a ritual dance under the full Moon. For now, a working Pipewire or Pulseaudio most likely be enough.
     Just specify HDMI as the audio sink in the mixer.
 
-To receive audio in the PiKVM Web UI, go to the **System** menu and switch the video mode to `WebRTC`.
-If everything is in order, the volume slider will appear. Set the volume to a non-zero value.
-The video stream will restart and you should start hearing sounds from the target host.
+To receive audio in the PiKVM Web UI, go to the **System** menu and switch the video mode
+to `WebRTC` or `Direct`. If everything is in order, the volume slider will appear.
+Set the volume to a non-zero value and you should start hearing sounds from the target host.
 
 <img src="menu_speakers.png" width="350" />
 
@@ -108,8 +108,8 @@ You can change everything together, but not separately.
         [root@pikvm ~]# reboot
         ```
 
-To receive and transmit audio in the PiKVM Web UI, go to the **System** menu and switch the video mode to `WebRTC`.
-If everything is in order, the volume slider will appear with additional Microphone switch.
+To receive and transmit audio in the PiKVM Web UI, go to the **System** menu and switch the video mode
+to `WebRTC` or `Direct`. If everything is in order, the volume slider will appear with additional Microphone switch.
 Set the volume to a non-zero value, next switch the mic switch.
 Your browser will ask for permission to use the microphone, allow it.
 
@@ -118,10 +118,9 @@ Your browser will ask for permission to use the microphone, allow it.
 The switch state will be saved in the browser's local settings.
 The microphone signal will not be transmitted if the volume level is zero.
 
-The microphone is also available in the `Direct` video mode, where the Multimedia section
-contains the Microphone switch only, since this mode has no speakers.
-Unlike `WebRTC`, only one browser at a time can use the microphone here,
-the others will get the busy error.
+Only one browser at a time can use the microphone, the others will get the busy error.
+The same applies to the video modes: the `WebRTC` and `Direct` modes use the same audio devices,
+so a session in one of them holds the microphone and the speakers until it's closed.
 
 
 -----

--- a/docs/audio.md
+++ b/docs/audio.md
@@ -122,6 +122,14 @@ Only one browser at a time can use the microphone, the others will get the busy 
 The same applies to the video modes: the `WebRTC` and `Direct` modes use the same audio devices,
 so a session in one of them holds the microphone and the speakers until it's closed.
 
+The Multimedia section also contains a microphone level meter and the **Raw microphone**
+switch, in both the `WebRTC` and `Direct` modes. Normally the browser applies its own noise
+suppression and automatic gain control to the microphone. The raw mode turns both of them off,
+which is useful for music or a line-in source, but keep in mind that a quiet microphone will
+become much quieter too. The echo cancellation is never disabled, otherwise the target host
+would hear its own sound back through the microphone. The level meter shows what the host
+actually receives, that is, the signal after all the browser's processing.
+
 
 -----
 ## Troubleshooting

--- a/docs/audio.md
+++ b/docs/audio.md
@@ -13,7 +13,8 @@ This brings the user experience of working with voice applications on the remote
 
     * Audio does not work with DIY devices, either CSI or USB video dongles.
 
-    * [VNC](vnc.md) does not support audio, it only works in the Web UI in [WebRTC](video.md) mode.
+    * [VNC](vnc.md) does not support audio, it only works in the Web UI.
+        The speakers require the `WebRTC` video mode, the microphone works in the `Direct` mode too.
 
 
 -----
@@ -117,6 +118,11 @@ Your browser will ask for permission to use the microphone, allow it.
 The switch state will be saved in the browser's local settings.
 The microphone signal will not be transmitted if the volume level is zero.
 
+The microphone is also available in the `Direct` video mode, where the Multimedia section
+contains the Microphone switch only, since this mode has no speakers.
+Unlike `WebRTC`, only one browser at a time can use the microphone here,
+the others will get the busy error.
+
 
 -----
 ## Troubleshooting
@@ -124,6 +130,7 @@ The microphone signal will not be transmitted if the volume level is zero.
 * If the browser does not play sound or does not show audio slider, try a different browser
     and/or incognito mode without extensions. Firefox and Google Chrome works best.
 
-* Check the log: `journalctl -u kvmd-janus`.
+* Check the log: `journalctl -u kvmd-janus` for the `WebRTC` mode
+    or `journalctl -u kvmd-media` for the `Direct` one.
 
 * If nothing helped, please report about the problem [to our support](https://pikvm.org/support/)

--- a/docs/video.md
+++ b/docs/video.md
@@ -27,7 +27,7 @@ video.
 
     * If the `WebRTC` mode is not working, try the `Direct`.
 
-    * The `Direct` mode doesn't support audio yet. If you need audio, but `WebRTC` is not working, follow [this guide](webrtc_config.md).
+    * The `Direct` mode supports [two-way audio](audio.md) as well, with the same requirements as `WebRTC`.
 
 
 -----
@@ -125,7 +125,7 @@ It also uses H.264 encoding, but streams the video over regular HTTP (WebSocket)
 
     * ✅ The latency is low and stable too.
 
-    * ❌ No audio support right now (but it will).
+    * ✅ Provides [two-way audio](audio.md) on PiKVM [V3](v3.md) and [V4 Plus/Mini](v4.md).
 
     * ❌ Some [older browsers](https://caniuse.com/webcodecs) doesn't have the WebCodes support needed for this mode.
 


### PR DESCRIPTION
Docs for pikvm/kvmd#240, which brings both audio directions to the `Direct` video mode.
Please merge it after the code, since the text describes the behavior that comes with it.

* The audio now works in the `Direct` mode as well as `WebRTC`, so the notes and the
  step-by-step instructions mention both.
* Documents the new **Raw microphone** switch and the level meter, and the fact that the
  echo cancellation is never disabled.
* Says that the audio devices are exclusive: between browsers, and between the two video modes.
* `docs/video.md` no longer claims that the `Direct` mode has no audio (it said so twice).
